### PR TITLE
Fix api versioning setup

### DIFF
--- a/src/operator_app/api/v1/__init__.py
+++ b/src/operator_app/api/v1/__init__.py
@@ -1,12 +1,13 @@
 from fastapi import APIRouter
-from operator_app.api.v1.relay.relay_routes import router as relay_router
-from operator_app.api.v1.status.status_routes import router as status_router
-from operator_app.api.v1.pump.pump_routes import router as pump_router
-from operator_app.api.v1.pins.pin_routes import router as pin_router
+from .relay.relay_routes import router as relay_router
+from .status.status_routes import router as status_router
+from .pump.pump_routes import router as pump_router
+from .pins.pin_routes import router as pin_router
+from .calibrate_scales.calibrate_scales_routes import router as calibrate_scales_router
 
 
-router = APIRouter()
-router.include_router(relay_router, prefix="/relay")
-router.include_router(status_router, prefix="/status")
-router.include_router(pump_router, prefix="/pump")
-router.include_router(pin_router, prefix="/pin")
+v1_router = APIRouter()
+v1_router.include_router(relay_router, prefix="/relay")
+v1_router.include_router(status_router, prefix="/status")
+v1_router.include_router(pump_router, prefix="/pump")
+v1_router.include_router(pin_router, prefix="/pin")

--- a/src/operator_app/app.py
+++ b/src/operator_app/app.py
@@ -1,15 +1,7 @@
 from fastapi import FastAPI
-from operator_app.api.v1.relay.relay_routes import router as relay_router
-from operator_app.api.v1.status.status_routes import router as status_router
-from operator_app.api.v1.pump.pump_routes import router as pump_router
-from operator_app.api.v1.pins.pin_routes import router as pin_router
-from operator_app.api.v1.calibrate_scales.calibrate_scales_routes import router as calibrate_scales_router
+from operator_app.api.v1 import v1_router
 
 
 app = FastAPI()
 
-app.include_router(relay_router, prefix="/v1/relay")
-app.include_router(status_router, prefix="/v1/status")
-app.include_router(pump_router, prefix="/v1/pump")
-app.include_router(pin_router, prefix="/v1/pin")
-app.include_router(calibrate_scales_router, prefix="/v1/calibrate-scales")
+app.include_router(v1_router, prefix="/v1")


### PR DESCRIPTION
Fixed: 

- consolidate route imports in /api/v1/init.py
- rename router to v1_router
- remove redundant route imports in app.py